### PR TITLE
Refactor code after review

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,6 @@ Prerequisite
 How to run each test case
 -------------------------
 
-
-**Note** Test08/general_tls and Test08/mutual_tls need to edit the `constants.go` file by replacing the testIngressHostname value with your OCP cluster Ingress host.
-
 User can go to directory `tests/maistra` 
 - To run all the test cases: `go test -v`
 - To run a specific test case: `go test -run [test case number] -v`

--- a/tests/maistra/constants.go
+++ b/tests/maistra/constants.go
@@ -70,6 +70,7 @@ const (
 	egressGoogleYaml			= "testdata/egress/serviceEntry-google.yaml"
 	
 	jwtAuthYaml					= "testdata/policy/jwt-auth.yaml"
+	jwtURL 						= "https://raw.githubusercontent.com/istio/istio/release-1.0/security/tools/jwt/samples/demo.jwt"
 
 	livenessHTTPYaml 			= "testdata/health-check/liveness-http.yaml"
 	livenessCommandYaml 		= "testdata/health-check/liveness-command.yaml"
@@ -99,8 +100,4 @@ const (
 
 	testNamespace				= "bookinfo"
 	testUsername				= "jason"
-
-	// testIngressHostname is only used in Test08/general_tls and Test08/mutual_tls
-	testIngressHostname 		= "istio-ingressgateway-istio-system.tmorcloud2.jonqe.lab.eng.bos.redhat.com"
-	
 )

--- a/tests/maistra/tc_03_request_routing_test.go
+++ b/tests/maistra/tc_03_request_routing_test.go
@@ -28,10 +28,6 @@ import (
 
 
 func cleanup03(namespace string, kubeconfig string) {
-	if err := recover(); err != nil {
-		log.Infof("Test failed: %v", err)
-	}
-
 	log.Infof("# Cleanup. Following error can be ignored...")
 	util.KubeDelete(namespace, bookinfoAllv1Yaml, kubeconfig)
 	util.KubeDelete(namespace, bookinfoReviewTestv2Yaml, kubeconfig)
@@ -95,4 +91,10 @@ func Test03(t *testing.T) {
 		}
 	})
 	defer cleanup03(testNamespace, "")
+	defer func() {
+		// recover from panic if one occured. This allows cleanup to be executed after panic.
+		if err := recover(); err != nil {
+			log.Infof("Test failed: %v", err)
+		}
+	}()
 }

--- a/tests/maistra/tc_04_fault_injection_test.go
+++ b/tests/maistra/tc_04_fault_injection_test.go
@@ -28,10 +28,6 @@ import (
 
 
 func cleanup04(namespace string, kubeconfig string) {
-	if err := recover(); err != nil {
-		log.Infof("Test failed: %v", err)
-	}
-	
 	log.Infof("# Cleanup. Following error can be ignored...")
 	util.KubeDelete(namespace, bookinfoAllv1Yaml, kubeconfig)
 	log.Info("Waiting for rules to be cleaned up. Sleep 10 seconds...")
@@ -147,4 +143,10 @@ func Test04(t *testing.T) {
 			t)
 	})
 	defer cleanup04(testNamespace, "")
+	defer func() {
+		// recover from panic if one occured. This allows cleanup to be executed after panic.
+		if err := recover(); err != nil {
+			log.Infof("Test failed: %v", err)
+		}
+	}()
 }

--- a/tests/maistra/tc_05_traffic_shifting_test.go
+++ b/tests/maistra/tc_05_traffic_shifting_test.go
@@ -28,10 +28,6 @@ import (
 )
 
 func cleanup05(namespace, kubeconfig string) {
-	if err := recover(); err != nil {
-		log.Infof("Test failed: %v", err)
-	}
-	
 	log.Infof("# Cleanup. Following error can be ignored...")
 	util.KubeDelete(namespace, bookinfoAllv1Yaml, kubeconfig)
 	log.Info("Waiting for rules to be cleaned up. Sleep 10 seconds...")
@@ -164,4 +160,10 @@ func Test05(t *testing.T) {
 		}	
 	})
 	defer cleanup05(testNamespace, "")
+	defer func() {
+		// recover from panic if one occured. This allows cleanup to be executed after panic.
+		if err := recover(); err != nil {
+			log.Infof("Test failed: %v", err)
+		}
+	}()
 }

--- a/tests/maistra/tc_07_request_timeouts_test.go
+++ b/tests/maistra/tc_07_request_timeouts_test.go
@@ -26,18 +26,14 @@ import (
 	"istio.io/istio/tests/util"
 )
 
-func cleanup06(namespace, kubeconfig string) {
-	if err := recover(); err != nil {
-		log.Infof("Test failed: %v", err)
-	}
-	
+func cleanup07(namespace, kubeconfig string) {
 	log.Infof("# Cleanup. Following error can be ignored...")
 	util.KubeDelete(namespace, bookinfoAllv1Yaml, kubeconfig)
 	log.Info("Waiting for rules to be cleaned up. Sleep 10 seconds...")
 	time.Sleep(time.Duration(10) * time.Second)
 }
 
-func setup06(namespace, kubeconfig string) error {
+func setup07(namespace, kubeconfig string) error {
 	if err := util.KubeApply(namespace, bookinfoAllv1Yaml, kubeconfig); err != nil {
 		return err
 	}
@@ -59,9 +55,9 @@ func setTimeout(namespace, kubeconfig string) error {
 	return nil
 }
 
-func Test06(t *testing.T) {
-	log.Infof("# TC_06 Setting Request Timeouts")
-	Inspect(setup06(testNamespace, ""), "failed to apply rules", "", t)
+func Test07(t *testing.T) {
+	log.Infof("# TC_07 Setting Request Timeouts")
+	Inspect(setup07(testNamespace, ""), "failed to apply rules", "", t)
 	t.Run("timout", func(t *testing.T) {
 		Inspect(setTimeout(testNamespace, ""), "failed to apply rules", "", t)
 
@@ -77,6 +73,12 @@ func Test06(t *testing.T) {
 			"Success. Response timeout matches with expected.",
 			t)
 	})
-	defer cleanup06(testNamespace, "")
+	defer cleanup07(testNamespace, "")
+	defer func() {
+		// recover from panic if one occured. This allows cleanup to be executed after panic.
+		if err := recover(); err != nil {
+			log.Infof("Test failed: %v", err)
+		}
+	}()
 }
 

--- a/tests/maistra/tc_08_control_ingress_test.go
+++ b/tests/maistra/tc_08_control_ingress_test.go
@@ -26,11 +26,7 @@ import (
 	"istio.io/istio/tests/util"
 )
 
-func cleanup07(namespace, kubeconfig string) {
-	if err := recover(); err != nil {
-		log.Infof("Test failed: %v", err)
-	}
-	
+func cleanup08(namespace, kubeconfig string) {
 	log.Infof("# Cleanup. Following error can be ignored...")
 	OcDelete("", httpbinOCPRouteYaml, kubeconfig)
 	util.KubeDelete(namespace, httpbinGatewayYaml, kubeconfig)
@@ -77,8 +73,8 @@ func updateHttpbin(namespace, kubeconfig string) error {
 	return nil
 }
 
-func Test07 (t *testing.T) {
-	log.Infof("# TC_07 Control Ingress Traffic")
+func Test08 (t *testing.T) {
+	log.Infof("# TC_08 Control Ingress Traffic")
 	Inspect(deployHttpbin(testNamespace, ""), "failed to deploy httpbin", "", t)
 
 	t.Run("status_200", func(t *testing.T) {
@@ -96,5 +92,11 @@ func Test07 (t *testing.T) {
 		log.Infof("httpbin headers page returned in %d ms", duration)
 		Inspect(CheckHTTPResponse200(resp), "failed to get HTTP 200", resp.Status, t)
 	})
-	defer cleanup07(testNamespace, "")
+	defer cleanup08(testNamespace, "")
+	defer func() {
+		// recover from panic if one occured. This allows cleanup to be executed after panic.
+		if err := recover(); err != nil {
+			log.Infof("Test failed: %v", err)
+		}
+	}()
 }

--- a/tests/maistra/utils_common.go
+++ b/tests/maistra/utils_common.go
@@ -129,6 +129,9 @@ func GetWithJWT(url, token, host string) (*http.Response, error) {
 
 // CloseResponseBody ...
 func CloseResponseBody(r *http.Response) {
+	if r == nil {
+		return
+	}
 	if err := r.Body.Close(); err != nil {
 		log.Errora(err)
 	}

--- a/tests/maistra/utils_ocp.go
+++ b/tests/maistra/utils_ocp.go
@@ -28,12 +28,25 @@ import (
 )
 
 
+// TBD
 // OcLogin runs oc login command to log into the OCP CLI
 // the host and token can be found from OCP web console Command Line Tools
-func OcLogin(host, port, token string) error {
+/*
+func OcLogin(token string) error {
+	host, err := util.Shell("")
+	if err != nil {
+		return err
+	}
+
+	port, err := util.Shell("")
+	if err != nil {
+		return err
+	}
+
 	_, err := util.ShellMuteOutput("oc login https://%s:%s --token=%s", host, port, token)
 	return err
 }
+*/
 
 func ocCommand(subCommand, namespace, yamlFileName string, kubeconfig string) string {
 	if namespace == "" {
@@ -66,8 +79,6 @@ func GetOCPIngress(serviceName, podLabel, namespace, kubeconfig string, serviceT
 	return host
 }
 
-
-
 // GetSecureIngressPort returns the https ingressgateway port
 // "$(${OC_COMMAND} -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="https")].port}')"
 func GetSecureIngressPort(namespace, serviceName, kubeconfig string) string {
@@ -86,4 +97,13 @@ func GetSecureIngressPort(namespace, serviceName, kubeconfig string) string {
 		return ""
 	}
 	return port
+}
+
+// GetIngressHostIP returns the OCP ingressgateway Host IP address from the OCP router endpoint
+func GetIngressHostIP(kubeconfig string) (string, error) {
+	ip, err := util.Shell("kubectl get endpoints -n default -l router -o jsonpath='{.items[0].subsets[0].addresses[0].ip}' --kubeconfig=%s", kubeconfig)
+	if err != nil {
+		return "", err
+	}
+	return ip, nil
 }


### PR DESCRIPTION
- update tc 09, replace embeded curl shell command with http client func
- update tc 09 checkTeapot
- remove constant testIngressHostname, this is resolved dynamicaly now
- update idompotency design, each Test case func contains: (in order) tests execution, a defer cleanup func, a defer recover func. So when a panic occurs, Test case execution panic --> recover --> cleanup
- rename tc numbers for holding a number for Istio release 1.1 new test case