### PR TITLE
Remove unused Helper() function from TestHelper

### DIFF
--- a/pkg/util/test/test_helper.go
+++ b/pkg/util/test/test_helper.go
@@ -34,7 +34,6 @@ type TestHelper interface {
 	Fatalf(format string, args ...any)
 	Log(args ...any)
 	Logf(format string, args ...any)
-	Helper()
 
 	NewSubTest(name string) Test
 
@@ -89,10 +88,6 @@ func (t *testHelper) SkipNow() {
 
 func (t *testHelper) Skipped() bool {
 	return t.t.Skipped()
-}
-
-func (t *testHelper) Helper() {
-	t.t.Helper()
 }
 
 func (t *testHelper) Log(args ...any) {

--- a/pkg/util/test/test_helper_setup.go
+++ b/pkg/util/test/test_helper_setup.go
@@ -50,9 +50,6 @@ func (t *setupTestHelper) Skipped() bool {
 	panic("not applicable")
 }
 
-func (t *setupTestHelper) Helper() {
-}
-
 func (t *setupTestHelper) Log(args ...any) {
 	log.Log.Info(args...)
 }


### PR DESCRIPTION
Instead of calling the Helper() function on TestHelper, one needs to call it on testing.T for it to work properly.