### PR TITLE
Disable Route validation for SMCP -1 version install

### DIFF
--- a/pkg/tests/ossm/smoke_test.go
+++ b/pkg/tests/ossm/smoke_test.go
@@ -65,7 +65,7 @@ func TestSmoke(t *testing.T) {
 
 			t.LogStepf("Create SMCP %s and verify it becomes ready", fromVersion)
 			assertSMCPDeploysAndIsReady(t, fromVersion)
-			if env.GetSMCPVersion().GreaterThanOrEqual(version.SMCP_2_2) {
+			if env.GetSMCPVersion().GreaterThan(version.SMCP_2_2) {
 				assertRoutesExist(t)
 			}
 


### PR DESCRIPTION
There is an edge case when we install smcp -1 lower version of the operator, for example, 2.1, when the kiali pod it's not deployed because it's not supported anymore. So I disable the route validation for that case and we are going to still validate always after the upgrade. So we do not miss coverage